### PR TITLE
Add dark theme styling for blogs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,16 @@
+# Site settings
+remote_theme: jekyll/minima
+
+# Directory where posts will be stored
+collections_dir: blogs
+
+# Permalink structure for posts
+permalink: /blogs/:year/:month/:day/:title.html
+
+# Plugins for additional features
+plugins:
+  - jekyll-feed
+  - jekyll-seo-tag
+
+# Include special directories
 include: [.well-known]

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -1,0 +1,18 @@
+---
+---
+@import url('https://fonts.googleapis.com/css2?family=Fira+Sans:wght@400;700&display=swap');
+@import "minima";
+
+body {
+    background: #1a1a1a;
+    color: #e8eaed;
+    font-family: 'Fira Sans', Arial, sans-serif;
+}
+
+a {
+    color: #8ab4f8;
+}
+
+.site-header, .site-footer {
+    background: #222;
+}

--- a/blogs/_posts/2024-06-16-welcome.md
+++ b/blogs/_posts/2024-06-16-welcome.md
@@ -1,0 +1,5 @@
+---
+title: "Welcome to My Blog"
+---
+
+This is the first post on the new GitHub Pages blog. Markdown files placed in the `blogs/_posts` directory are automatically processed by Jekyll.

--- a/blogs/index.md
+++ b/blogs/index.md
@@ -1,0 +1,6 @@
+---
+layout: home
+title: "Blogs"
+---
+
+Welcome to the blog index. Here you will find all posts rendered from Markdown files in the `blogs/_posts` directory.

--- a/index.min.css
+++ b/index.min.css
@@ -1,17 +1,18 @@
+@import url('https://fonts.googleapis.com/css2?family=Fira+Sans:wght@400;700&display=swap');
 :root {
-    --textColor: #333333;
-    --background: #ffffff;
-    --accentColor: #3cb371;
-    --button: #2e8b57;
-    --hoverColor: #f0f0f0;
+    --textColor: #e8eaed;
+    --background: #1a1a1a;
+    --accentColor: #3498db;
+    --button: #1e88e5;
+    --hoverColor: #2b2b2b;
     --grayColor: #858585;
     --iconURL: url(/icon.png);
 }
-@media (prefers-color-scheme: dark) {
+@media (prefers-color-scheme: light) {
     :root {
-        --textColor: #d3d3d3;
-        --background: #1a1a1a;
-        --hoverColor: #2b2b2b;
+        --textColor: #333333;
+        --background: #ffffff;
+        --hoverColor: #f0f0f0;
     }
 }
 
@@ -19,6 +20,7 @@ html,
 body {
     margin: 0px;
     padding: 0px;
+    font-family: 'Fira Sans', Arial, sans-serif;
     background-color: var(--background);
     color: var(--textColor);
 }
@@ -65,8 +67,11 @@ ul {
     list-style: none;
 }
 li a {
-    color: white;
+    color: var(--accentColor);
     font-size: 15pt;
+}
+li a:hover {
+    text-decoration: underline;
 }
 li:first-child a {
     font-size: 20pt;


### PR DESCRIPTION
## Summary
- create `assets/main.scss` to override minima theme with a dark palette
- refresh site CSS colors and fonts for a sleeker look

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685020daaac08322a0326de5606253a1