### PR TITLE
Fix remote theme issue

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 # Site settings
-remote_theme: jekyll/minima
+theme: minima
 
 # Directory where posts will be stored
 collections_dir: blogs


### PR DESCRIPTION
## Summary
- fix Jekyll theme configuration so builds don't need remote downloads

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685022bd48dc83228c3483b0ec0f1212