### PR TITLE
Update color scheme for readability

### DIFF
--- a/index.min.css
+++ b/index.min.css
@@ -1,18 +1,20 @@
 @import url('https://fonts.googleapis.com/css2?family=Fira+Sans:wght@400;700&display=swap');
 :root {
-    --textColor: #e8eaed;
-    --background: #1a1a1a;
-    --accentColor: #3498db;
-    --button: #1e88e5;
-    --hoverColor: #2b2b2b;
+    --textColor: #ececf1;
+    --background: #343541;
+    --accentColor: #19c37d;
+    --button: #202123;
+    --hoverColor: #40414f;
     --grayColor: #858585;
     --iconURL: url(/icon.png);
 }
 @media (prefers-color-scheme: light) {
     :root {
-        --textColor: #333333;
+        --textColor: #202123;
         --background: #ffffff;
-        --hoverColor: #f0f0f0;
+        --accentColor: #19c37d;
+        --button: #e5e5e5;
+        --hoverColor: #f5f5f5;
     }
 }
 


### PR DESCRIPTION
## Summary
- tweak CSS variables to mimic ChatGPT colours

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6850244591b48322bb750f02d277e4da